### PR TITLE
CI: Use v2 tag of actions/checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
 
       - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1


### PR DESCRIPTION
This PR is cleanup detail: use a released version of the checkout action.