### PR TITLE
Stop double-decoding gzip

### DIFF
--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -27,7 +27,7 @@ module Faraday
             # file: 'path/to/file', # stream data off disk
           }
           configure_compression(options, env)
-          options
+          options.merge(decoding: false)
         end
 
         def read_body(env)


### PR DESCRIPTION
By default em-http decodes gzip content and leaves the Content-Encoding header
intact, which is then detected by Faraday middleware and the gzip decoding is
attempted again leading to exceptions.

This change requests that em-http *not* handle the gzip decoding, so that the
Faraday middleware can do it.