### PR TITLE
refactor: Make CI more regular

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+    branches: [main]
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    types: [assigned, opened, synchronize, reopened]
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, setup-ci]
+    branches: [main]
   schedule:
     - cron: '0 8 * * 1' # At 8:00 on Monday
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
   push:
     branches: [main]
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Rubocop
-        run: |
-          bin/setup
-          bin/ci-lint
+        run: bundle exec rubocop --format progress
 
   test:
     needs: [lint]
@@ -41,11 +40,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-
-      - name: Build
-        run: |
-          bin/setup
+          bundler-cache: true # 'bundle install' and cache
 
       - name: Test
-        run: |
-          bin/ci-test
+        run: bundle exec rspec

--- a/bin/ci-lint
+++ b/bin/ci-lint
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
-
-bundle exec rubocop --format progress

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
-
-bundle exec rspec


### PR DESCRIPTION
This PR removes two scripts, drops a specific merged branch from CI config, and uses the caching features in ruby/setup-ruby.

Haha, I found that the CI workflow had been _disabled_, due to this repo **not having activity** during the past period of time. Perhaps a New Workflow that does the same thing needs to be created to avoid this?