### PR TITLE
Depend on Faraday 2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.6', '2.7', '3.0', '3.1']
 
     steps:
       - uses: actions/checkout@v2

--- a/faraday-em_http.gemspec
+++ b/faraday-em_http.gemspec
@@ -22,9 +22,8 @@ Gem::Specification.new do |spec|
   spec.files = Dir.glob('lib/**/*') + %w[README.md LICENSE.md]
   spec.require_paths = ['lib']
 
-  # TODO: make these normal dependencies when releasing v2.0 together with Faraday v2.0
-  spec.add_development_dependency 'em-http-request', '>= 1.1'
-  spec.add_development_dependency 'faraday', '~> 1.0'
+  spec.add_runtime_dependency 'em-http-request', '>= 1.1'
+  spec.add_runtime_dependency 'faraday', '~> 2.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -1,4 +1,17 @@
 # frozen_string_literal: true
+require 'em-http'
+
+begin
+  require 'openssl'
+rescue LoadError
+  warn 'Warning: no such file to load -- openssl. ' \
+    'Make sure it is installed if you want HTTPS support'
+else
+  require 'em-http/version'
+  if EventMachine::HttpRequest::VERSION < '1.1.6'
+    require 'faraday/adapter/em_http_ssl_patch'
+  end
+end
 
 module Faraday
   class Adapter
@@ -89,22 +102,6 @@ module Faraday
       end
 
       include Options
-
-      dependency do
-        require 'em-http'
-
-        begin
-          require 'openssl'
-        rescue LoadError
-          warn 'Warning: no such file to load -- openssl. ' \
-            'Make sure it is installed if you want HTTPS support'
-        else
-          require 'em-http/version'
-          if EventMachine::HttpRequest::VERSION < '1.1.6'
-            require 'faraday/adapter/em_http_ssl_patch'
-          end
-        end
-      end
 
       self.supports_parallel = true
 

--- a/lib/faraday/adapter/em_http.rb
+++ b/lib/faraday/adapter/em_http.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'em-http'
 
 begin

--- a/lib/faraday/em_http.rb
+++ b/lib/faraday/em_http.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'faraday'
 require_relative 'adapter/em_http'
 require_relative 'em_http/version'
 


### PR DESCRIPTION
* Drop Ruby 2.5 from CI, Faraday 2.0 requires a newer Ruby
* replace `dependency` with `require`