### PR TITLE
CI: rely on .ruby-version for the linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.7
+      - name: Set up latest Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
           bundler-cache: true # 'bundle install' and cache
 
       - name: Rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@
 
 source 'https://rubygems.org'
 gemspec
+
+group :linting do
+  gem 'rubocop'
+  gem 'rubocop-packaging'
+  gem 'rubocop-performance'
+end

--- a/faraday-em_http.gemspec
+++ b/faraday-em_http.gemspec
@@ -32,8 +32,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'multipart-parser', '~> 0.1.1'
   spec.add_development_dependency 'webmock', '~> 3.4'
-
-  spec.add_development_dependency 'rubocop', '~> 0.91.1'
-  spec.add_development_dependency 'rubocop-packaging', '~> 0.5'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.0'
 end


### PR DESCRIPTION
The linting task will use the Ruby offered in the .ruby-version file.