### PR TITLE
CI: Use Ruby 3.3 in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.7
+      - name: Set up latest Ruby
         uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.7.x
 
       - name: Publish to RubyGems
         run: |


### PR DESCRIPTION
The .ruby-version file contains the version to be used by default.